### PR TITLE
Fix issues on Rancher versions > v2.x

### DIFF
--- a/machine/driver/driver.go
+++ b/machine/driver/driver.go
@@ -267,7 +267,7 @@ func (d *VultrDriver) Create() (err error) {
 	}
 
 	// Allow docker through the firewall. Every vultr OS uses ufw
-	d.appendToCloudInitUserDataCloudConfig([]byte("\r\nruncmd:\r\n  - ufw allow " + cast.ToString(d.DockerPort) + "\r\n  - ufw allow " + cast.ToString(rancherCatalogPort) + "\r\n  - ufw allow " + cast.ToString(rancherCatalogPort)))
+	d.appendToCloudInitUserDataCloudConfig([]byte("\r\nruncmd:\r\n  - ufw allow " + cast.ToString(d.DockerPort) + "\r\n  - ufw allow " + cast.ToString(rancherCatalogPort) + "\r\n  - ufw allow " + cast.ToString(rancherCatalogPort) + "\r\n  - ufw disable"))
 
 	// Create instance
 	d.ResponsePayloads.Instance, err = vultrClient.Instance.Create(context.Background(), &d.RequestPayloads.InstanceCreateReq)
@@ -286,11 +286,12 @@ func (d *VultrDriver) Create() (err error) {
 			<-time.After(5 * time.Second)
 			continue
 		}
-		// We need to also set the IP in the base driver
-		d.IPAddress = _ip
 		log.Infof("VPS %s is now configured with ip address %s", d.BaseDriver.MachineName, _ip)
 		break
 	}
+
+	// We need to also set the IP in the base driver
+	d.IPAddress, _ = d.GetIP()
 
 	return nil
 }

--- a/machine/driver/driver.go
+++ b/machine/driver/driver.go
@@ -286,6 +286,8 @@ func (d *VultrDriver) Create() (err error) {
 			<-time.After(5 * time.Second)
 			continue
 		}
+		// We need to also set the IP in the base driver
+		d.IPAddress = _ip
 		log.Infof("VPS %s is now configured with ip address %s", d.BaseDriver.MachineName, _ip)
 		break
 	}

--- a/machine/driver/driver.go
+++ b/machine/driver/driver.go
@@ -555,17 +555,13 @@ func (d *VultrDriver) addUFWCommandsToCloudInitUserDataCloudConfig() {
 
 	// Now add all the UFW rules
 	for _, _port := range d.UFWPortsToOpen {
-
-		// Prevent multiple conversions
-		portAsString := cast.ToString(_port)
-
 		// A little insurance to make sure we opened the docker port
-		if portAsString == dockerPortAsString {
+		if _port == dockerPortAsString {
 			dockerPortWasOpened = true
 		}
 
 		// Add to the cloud init user data cloud config
-		d.appendToCloudInitUserDataCloudConfig([]byte("\r\n  - ufw allow " + portAsString))
+		d.appendToCloudInitUserDataCloudConfig([]byte("\r\n  - ufw allow " + _port))
 	}
 
 	// Docker port was NOT opened, lets do that

--- a/machine/driver/driver.go
+++ b/machine/driver/driver.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	defaultOSID        = 352 // Currently only works on debian 10
+	defaultOSID        = 387 // Ubuntu 20.04
 	defaultRegion      = "ewr"
 	defaultPlan        = "vc2-1c-2gb"
 	defaultDockerPort  = 2376
@@ -83,7 +83,7 @@ func (d *VultrDriver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.IntFlag{
 			EnvVar: "VULTR_OSID",
 			Name:   "vultr-os-id",
-			Usage:  "Operating system ID (default: [352] Debian 10)",
+			Usage:  "Operating system ID (default: [387] Ubuntu 20.04)",
 			Value:  defaultOSID,
 		},
 		mcnflag.StringFlag{


### PR DESCRIPTION
## Description
Rancher versions greater than v2.x were throwing an error `Failed to validate cluster: Address for host (1) is not provided`

Rancher v2 now enforces `IPAddress` to be set in the base driver `https://github.com/docker/machine/blob/15fd4c70403bab784d91031af02d9e169ce66412/libmachine/drivers/base.go#L17`

I also added in all the default firewall rules and supplied configuration options to adjust these firewall rules or just downright disable the firewall all together

### Checklist:

* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ x] Have you linted your code locally prior to submission?
* [ x] Have you successfully ran tests with your changes locally?
