### PR TITLE
Fix vultr-snapshot-id flag being ignored

### DIFF
--- a/machine/driver/driver.go
+++ b/machine/driver/driver.go
@@ -243,6 +243,7 @@ func (d *VultrDriver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 	d.RequestPayloads.InstanceCreateReq.FirewallGroupID = opts.String("vultr-firewall-group-id")
 	d.RequestPayloads.InstanceCreateReq.IPXEChainURL = opts.String("vultr-ipxe-chain-url")
 	d.RequestPayloads.InstanceCreateReq.ScriptID = opts.String("vultr-startup-script-id")
+	d.RequestPayloads.InstanceCreateReq.SnapshotID = opts.String("vultr-snapshot-id")
 	d.RequestPayloads.InstanceCreateReq.EnableIPv6 = utils.BoolPtr(opts.Bool("vultr-enabled-ipv6"))
 	d.RequestPayloads.InstanceCreateReq.EnableVPC = utils.BoolPtr(opts.Bool("vultr-enable-vpc"))
 	d.RequestPayloads.InstanceCreateReq.AttachVPC = opts.StringSlice("vultr-vpc-ids")


### PR DESCRIPTION
## Description
This PR changes the flag parsing to properly pass the given snapshot ID to the API request.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
