### PR TITLE
added automatic firewall rule addition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/docker/machine v0.16.2
 	github.com/rancher/machine v0.13.0
-	github.com/sirupsen/logrus v1.9.0
 	github.com/vultr/govultr/v2 v2.17.2
 	golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c
 )
@@ -18,6 +17,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/moby/term v0.5.0 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/net v0.0.0-20220728211354-c7608f3a8462 // indirect
 	golang.org/x/sys v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rancher/machine v0.13.0 h1:UZa0XFS0K9zfNoRr6JWRgeds9XWGK5c4UZnJnVZkjVQ=
 github.com/rancher/machine v0.13.0/go.mod h1:1UV3lGqLhmjRp8Wd3P8cTsKUCs/9GY6He5jGfg6NGB0=
-github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
@@ -48,7 +46,6 @@ golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c h1:q3gFqPqH7NVofKo3c3yETA
 golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 h1:Q5284mrmYTpACcm+eAKjKJH48BBwSyfJqmmGDTtT8Vc=

--- a/machine/driver/driver.go
+++ b/machine/driver/driver.go
@@ -30,8 +30,9 @@ type Driver struct {
 	ResponsePayloads struct {
 		Instance *govultr.Instance
 	}
-	APIKey     string
-	InstanceID string
+	APIKey         string
+	InstanceID     string
+	FirewallRuleID int
 }
 
 // GetCreateFlags ... returns the mcnflag.Flag slice representing the flags
@@ -249,6 +250,10 @@ func (d *Driver) Create() (err error) {
 		return err
 	}
 
+	if d.RequestPayloads.InstanceCreateReq.FirewallGroupID != "" {
+		d.addMachineToFirewall()
+	}
+
 	return nil
 }
 
@@ -287,6 +292,10 @@ func (d *Driver) Remove() error {
 	if err := d.getVultrClient().Instance.Delete(context.Background(), d.InstanceID); err != nil {
 		log.Errorf("Error deleting VPS %s: [%v]", d.BaseDriver.MachineName, err)
 		return err
+	}
+
+	if d.FirewallRuleID > 0 {
+		d.getVultrClient().FirewallRule.Delete(context.Background(), d.RequestPayloads.InstanceCreateReq.FirewallGroupID, d.FirewallRuleID)
 	}
 
 	return nil


### PR DESCRIPTION
This PR will make the docker-machine driver automatically add/remove a firewall rule to the given firewall if specified. This will allow clusters to speak to each other if a Vultr firewall is used. 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
