### PR TITLE
Support cloud-init userdata from file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.5
 
 require (
+	github.com/goccy/go-yaml v1.18.0
 	github.com/rancher/machine v0.15.0-rancher126
 	github.com/vultr/govultr/v3 v3.14.1
 	golang.org/x/oauth2 v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/docker/docker v20.10.17+incompatible h1:JYCuMrWaVNophQTOrMMoSwudOVEfc
 github.com/docker/docker v20.10.17+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
+github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/machine/driver/driver.go
+++ b/machine/driver/driver.go
@@ -2,8 +2,10 @@ package driver
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -139,7 +141,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "VULTR_CLOUD_INIT_USER_DATA",
 			Name:   "vultr-cloud-init-user-data",
 			Usage:  "Pass base64 encoded cloud-init user data to this resource to execute after successful provision. Default Cloud-Init provided disables UFW ",
-			Value:  "I2Nsb3VkLWNvbmZpZwoKcnVuY21kOgogLSB1ZncgZGlzYWJsZQ==",
+		},
+		mcnflag.BoolFlag{
+			EnvVar: "VULTR_CLOUD_INIT_FROM_FILE",
+			Name:   "vultr-cloud-init-from-file",
+			Usage:  "Pass --vultr-cloud-init-user-data as a file path instead of base64 encoded string",
 		},
 		mcnflag.StringFlag{
 			EnvVar: "VULTR_FLOATING_IPV4_ID",
@@ -190,9 +196,31 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 	d.RequestPayloads.InstanceCreateReq.AttachVPC = opts.StringSlice("vultr-vpc-ids")
 	d.RequestPayloads.InstanceCreateReq.SSHKeys = opts.StringSlice("vultr-ssh-key-ids")
 	d.RequestPayloads.InstanceCreateReq.DDOSProtection = utils.BoolPtr(opts.Bool("vultr-ddos-protection"))
-	d.RequestPayloads.InstanceCreateReq.UserData = opts.String("vultr-cloud-init-user-data")
 	d.RequestPayloads.InstanceCreateReq.ReservedIPv4 = opts.String("vultr-floating-ipv4-id")
 	d.RequestPayloads.InstanceCreateReq.ActivationEmail = utils.BoolPtr(opts.Bool("vultr-send-activation-email"))
+
+	cloudInitFromFile := opts.Bool("vultr-cloud-init-from-file")
+	cloudInitUserData := opts.String("vultr-cloud-init-user-data")
+
+	if cloudInitFromFile {
+		data, err := os.ReadFile(cloudInitUserData)
+		if err != nil {
+			return fmt.Errorf("failed to read cloud-init file %q: %w", cloudInitUserData, err)
+		}
+
+		userData := string(data)
+
+		idx := "runcmd:"
+		formatCloudConfig := strings.Index(userData, idx) + len(idx)
+
+		userData = userData[:formatCloudConfig] + "\n- ufw disable" + userData[formatCloudConfig:]
+		d.RequestPayloads.InstanceCreateReq.UserData = base64.StdEncoding.EncodeToString([]byte(userData))
+	} else {
+		if cloudInitUserData == "" {
+			cloudInitUserData = "I2Nsb3VkLWNvbmZpZwoKcnVuY21kOgogLSB1ZncgZGlzYWJsZQ=="
+		}
+		d.RequestPayloads.InstanceCreateReq.UserData = cloudInitUserData
+	}
 
 	return nil
 }

--- a/machine/driver/driver.go
+++ b/machine/driver/driver.go
@@ -19,16 +19,14 @@ import (
 )
 
 const (
-	defaultOSID   = 1743 // Ubuntu 22.04
-	defaultRegion = "ewr"
-	defaultPlan   = "vc2-1c-2gb"
-)
-
-const defaultCloudConfig = `
-#cloud-config
+	defaultOSID        = 1743 // Ubuntu 22.04
+	defaultRegion      = "ewr"
+	defaultPlan        = "vc2-1c-2gb"
+	defaultCloudConfig = `#cloud-config
 runcmd:
 - '[ -x "$(command -v ufw)" ] && ufw disable'
 `
+)
 
 // Driver ... driver struct
 type Driver struct {
@@ -241,7 +239,7 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 				return fmt.Errorf("failed to unmarshal cloud config: %w", err)
 			}
 
-			config.RunCmd = append(config.RunCmd, `[ -x "$(command -v ufw)" ] && ufw disable`)
+			config.RunCmd = append(config.RunCmd, "[ -x \"$(command -v ufw)\" ] && ufw disable")
 
 			updatedCloudConfig, err := yaml.Marshal(&config)
 			if err != nil {

--- a/machine/driver/driver.go
+++ b/machine/driver/driver.go
@@ -24,6 +24,12 @@ const (
 	defaultPlan   = "vc2-1c-2gb"
 )
 
+const defaultCloudConfig = `
+#cloud-config
+runcmd:
+- '[ -x "$(command -v ufw)" ] && ufw disable'
+`
+
 // Driver ... driver struct
 type Driver struct {
 	*drivers.BaseDriver
@@ -225,7 +231,7 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 	if cloudInitFromFile {
 		data, err := os.ReadFile(cloudInitUserData)
 		if err != nil {
-			return fmt.Errorf("failed to read cloud-init file %q: %w", cloudInitUserData, err)
+			return fmt.Errorf("failed to read cloud-init file: %w", err)
 		}
 
 		if disableUFW {
@@ -251,7 +257,7 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 		}
 	} else {
 		if cloudInitUserData == "" {
-			cloudInitUserData = "I2Nsb3VkLWNvbmZpZwoKcnVuY21kOgogLSB1ZncgZGlzYWJsZQ=="
+			cloudInitUserData = base64.StdEncoding.EncodeToString([]byte(defaultCloudConfig))
 		}
 		d.RequestPayloads.InstanceCreateReq.UserData = cloudInitUserData
 	}

--- a/machine/driver/driver.go
+++ b/machine/driver/driver.go
@@ -235,7 +235,7 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 				return fmt.Errorf("failed to unmarshal cloud config: %w", err)
 			}
 
-			config.RunCmd = append(config.RunCmd, "ufw disable")
+			config.RunCmd = append(config.RunCmd, `[ -x "$(command -v ufw)" ] && ufw disable`)
 
 			updatedCloudConfig, err := yaml.Marshal(&config)
 			if err != nil {

--- a/machine/driver/driver.go
+++ b/machine/driver/driver.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/rancher/machine/libmachine/log"
 	"github.com/rancher/machine/libmachine/mcnflag"
@@ -35,6 +36,19 @@ type Driver struct {
 	APIKey         string
 	InstanceID     string
 	FirewallRuleID int
+}
+
+type CloudConfig struct {
+	Hostname   string      `yaml:"hostname,omitempty"`
+	RunCmd     []string    `yaml:"runcmd,omitempty"`
+	WriteFiles []WriteFile `yaml:"write_files,omitempty"`
+}
+
+type WriteFile struct {
+	Content     string `yaml:"content"`
+	Encoding    string `yaml:"encoding,omitempty"`
+	Path        string `yaml:"path"`
+	Permissions string `yaml:"permissions,omitempty"`
 }
 
 // GetCreateFlags ... returns the mcnflag.Flag slice representing the flags
@@ -147,6 +161,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "vultr-cloud-init-from-file",
 			Usage:  "Pass --vultr-cloud-init-user-data as a file path instead of base64 encoded string",
 		},
+		mcnflag.BoolFlag{
+			EnvVar: "VULTR_DISABLE_UFW",
+			Name:   "vultr-disable-ufw",
+			Usage:  "Disable UFW (default: enabled)",
+		},
 		mcnflag.StringFlag{
 			EnvVar: "VULTR_FLOATING_IPV4_ID",
 			Name:   "vultr-floating-ipv4-id",
@@ -201,6 +220,7 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 
 	cloudInitFromFile := opts.Bool("vultr-cloud-init-from-file")
 	cloudInitUserData := opts.String("vultr-cloud-init-user-data")
+	disableUFW := opts.Bool("vultr-disable-ufw")
 
 	if cloudInitFromFile {
 		data, err := os.ReadFile(cloudInitUserData)
@@ -208,20 +228,33 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 			return fmt.Errorf("failed to read cloud-init file %q: %w", cloudInitUserData, err)
 		}
 
-		userData := string(data)
+		if disableUFW {
+			cloudConfigHeader := strings.TrimPrefix(string(data), "#cloud-config\n")
+			var config CloudConfig
+			if err := yaml.Unmarshal([]byte(cloudConfigHeader), &config); err != nil {
+				return fmt.Errorf("failed to unmarshal cloud config: %w", err)
+			}
 
-		idx := "runcmd:"
-		formatCloudConfig := strings.Index(userData, idx) + len(idx)
+			config.RunCmd = append(config.RunCmd, "ufw disable")
 
-		userData = userData[:formatCloudConfig] + "\n- ufw disable" + userData[formatCloudConfig:]
-		d.RequestPayloads.InstanceCreateReq.UserData = base64.StdEncoding.EncodeToString([]byte(userData))
+			updatedCloudConfig, err := yaml.Marshal(&config)
+			if err != nil {
+				return fmt.Errorf("failed to marshal updated cloud-init data: %w", err)
+			}
+
+			newData := append([]byte("#cloud-config\n"), updatedCloudConfig...)
+			encodedUD := base64.StdEncoding.EncodeToString(newData)
+			d.RequestPayloads.InstanceCreateReq.UserData = encodedUD
+		} else {
+			encodedUD := base64.StdEncoding.EncodeToString(data)
+			d.RequestPayloads.InstanceCreateReq.UserData = encodedUD
+		}
 	} else {
 		if cloudInitUserData == "" {
 			cloudInitUserData = "I2Nsb3VkLWNvbmZpZwoKcnVuY21kOgogLSB1ZncgZGlzYWJsZQ=="
 		}
 		d.RequestPayloads.InstanceCreateReq.UserData = cloudInitUserData
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->

Add support for cloud-init based userdata from a file, needed for bootstrapping RKE2 clusters via rancher while using the vultr-docker-machine-driver

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
